### PR TITLE
fix: 내부 문제가 있는 경우, 복구하는 방법에 예외가 잘못되어 있던 문제를 수정하라

### DIFF
--- a/clean-code/initial/src/test/java/cholog/ExceptionHandlingTest.java
+++ b/clean-code/initial/src/test/java/cholog/ExceptionHandlingTest.java
@@ -495,7 +495,7 @@ public class ExceptionHandlingTest {
                 class BrokenVendingMachine extends VendingMachine {
                     @Override
                     Item selectItemByName(final String name) {
-                        throw new IllegalArgumentException("아이템을 뽑는 데 실패했습니다.");
+                        throw new IllegalStateException("아이템을 뽑는 데 실패했습니다.");
                     }
                 }
 


### PR DESCRIPTION
### 변경 사항

```java
@Test
@DisplayName("내부 문제가 있다면 외부에서 처리하도록 하는 방법은 없을까?")
void 내부_문제가_있다면_외부에서_처리하도록_하는_방법은_없을까() {
    class BrokenVendingMachine extends VendingMachine {
        @Override
        Item selectItemByName(final String name) {
            // 이 부분의 예외를 IllegalStateException으로 변경했습니다. 
            // 아래의 복구 코드와 다른 예외를 던지고 있습니다.
            throw new IllegalArgumentException("아이템을 뽑는 데 실패했습니다.");
        }
    }

    final class CustomVendingMachine extends BrokenVendingMachine {
        // TODO: 내부 문제가 있다면 외부에서 처리하도록 하는 방법은 없을까?
        @Override
        Item selectItemByName(final String name) {
            try {
                return super.selectItemByName(name);
            } catch (final IllegalStateException e) {
                // Note: 한 가지 방법을 재시도하는 것은 하나의 방법일 뿐 내부 정책에 따라 복구하는 방법은 달라질 수 있습니다. 예를 들어 해당 아이템을 뽑는데 실패했다면, 다음 아이템을 주는 방식도 복구라고 할 수 있습니다.
                return selectItemByName(name);
            }
        }
    }
```

- 내부 예외가, `IllegalArgumentsException`으로 되어 있고 외부 복구 작업 코드가 `IllegalStateException`으로 되어 있어 예외가 잡히지 않는 문제를 변경했습니다.
